### PR TITLE
Upgrading dependencies to psc 0.10.1 and bumping version to 1.0.0?

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,18 +18,18 @@
     "bower.json"
   ],
   "dependencies": {
-    "purescript-prelude": "^1.0.1",
-    "purescript-control": "^1.0.0",
-    "purescript-lists": "^1.0.1",
-    "purescript-foldable-traversable": "^1.0.0",
-    "purescript-maybe": "^1.0.0",
-    "purescript-tuples": "^1.0.0",
-    "purescript-unfoldable": "^1.0.0"
+    "purescript-prelude": "^2.1.0",
+    "purescript-control": "^2.0.0",
+    "purescript-lists": "^3.2.0",
+    "purescript-foldable-traversable": "^2.0.0",
+    "purescript-maybe": "^2.0.1",
+    "purescript-tuples": "^3.0.0",
+    "purescript-unfoldable": "^2.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^1.0.0",
-    "purescript-quickcheck": "^1.0.0",
-    "purescript-quickcheck-laws": "^1.0.0"
+    "purescript-console": "^2.0.0",
+    "purescript-quickcheck": "^3.0.0",
+    "purescript-quickcheck-laws": "^2.0.0"
   },
   "version": "0.1.0"
 }

--- a/bower.json
+++ b/bower.json
@@ -31,5 +31,5 @@
     "purescript-quickcheck": "^3.0.0",
     "purescript-quickcheck-laws": "^2.0.0"
   },
-  "version": "0.1.0"
+  "version": "1.0.0"
 }

--- a/bower.json
+++ b/bower.json
@@ -18,18 +18,18 @@
     "bower.json"
   ],
   "dependencies": {
-    "purescript-prelude": "^2.1.0",
-    "purescript-control": "^2.0.0",
-    "purescript-lists": "^3.2.0",
-    "purescript-foldable-traversable": "^2.0.0",
-    "purescript-maybe": "^2.0.1",
-    "purescript-tuples": "^3.0.0",
-    "purescript-unfoldable": "^2.0.0"
+    "purescript-prelude": "^3.0.0",
+    "purescript-control": "^3.0.0",
+    "purescript-lists": "^4.0.0",
+    "purescript-foldable-traversable": "^3.0.0",
+    "purescript-maybe": "^3.0.0",
+    "purescript-tuples": "^4.0.0",
+    "purescript-unfoldable": "^3.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^2.0.0",
-    "purescript-quickcheck": "^3.0.0",
-    "purescript-quickcheck-laws": "^2.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-quickcheck": "^4.0.0",
+    "purescript-quickcheck-laws": "git://github.com/soupi/purescript-quickcheck-laws.git#38327d5"
   },
-  "version": "1.0.0"
+  "version": "2.0.0"
 }

--- a/src/Data/List/Zipper.purs
+++ b/src/Data/List/Zipper.purs
@@ -102,7 +102,7 @@ instance functorZipper :: Functor Zipper where
 
 instance extendZipper :: Extend Zipper where
     -- extend :: forall b a. (Zipper a -> b) -> Zipper a -> Zipper b
-    extend f = Zipper <$> go f up <*> f <*> go f down
+    extend g = Zipper <$> go g up <*> g <*> go g down
         where go f d = (<$>) f <<< maybeIterate d
 
 instance comonadZipper :: Comonad Zipper where

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,7 +2,6 @@ module Test.Main where
 
 import Prelude
 
-import Control.Bind                             ((<=<))
 import Control.Monad.Eff                        (Eff())
 import Control.Monad.Eff.Console                (CONSOLE(), log)
 import Control.Monad.Eff.Random                 (RANDOM())

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -42,12 +42,7 @@ import Control.Comonad (class Comonad, extract)
 import Data.Unfoldable (class Unfoldable)
 
 
-main :: forall eff. Eff
-        ( console :: CONSOLE
-        , random :: RANDOM
-        , err :: EXCEPTION
-        | eff)
-        Unit
+main :: Eff (console :: CONSOLE, random :: RANDOM, exception :: EXCEPTION) Unit
 main = do
     log "Checking that `show` is total"
     quickCheck $ const Success $ show :: ArbitraryZipper Number -> String
@@ -98,10 +93,10 @@ prxB = Proxy
 prxC :: Proxy Int
 prxC = Proxy
 
-notUnequal :: forall a. (Eq a, Show a) => (a -> Maybe a) -> (a -> Maybe a) -> a -> Result
+notUnequal :: forall a. Eq a => Show a => (a -> Maybe a) -> (a -> Maybe a) -> a -> Result
 notUnequal f g x = maybe Success id $ (===) <$> f x <*> g x
 
-idempotent :: forall a. (Eq a) => (a -> a) -> a -> Boolean
+idempotent :: forall a. Eq a => (a -> a) -> a -> Boolean
 idempotent f = eq <$> f <<< f <*> f
 
 -- We can't make an arbitrary instance here for Zipper itself, because of orphan instances.
@@ -110,11 +105,11 @@ idempotent f = eq <$> f <<< f <*> f
 -- here, so that we're really testing Zipper.
 newtype ArbitraryZipper a = ArbitraryZipper (Zipper a)
 
-instance arbArbitraryZipper :: (Arbitrary a) => Arbitrary (ArbitraryZipper a) where
+instance arbArbitraryZipper :: Arbitrary a => Arbitrary (ArbitraryZipper a) where
     -- arbitrary :: forall a. (Arbitrary a) => Gen (Zipper a)
     arbitrary = ArbitraryZipper <$> (Zipper <$> arbitrary <*> arbitrary <*> arbitrary)
 
-instance coarbArbitraryZipper :: (Coarbitrary a) => Coarbitrary (ArbitraryZipper a) where
+instance coarbArbitraryZipper :: Coarbitrary a => Coarbitrary (ArbitraryZipper a) where
     coarbitrary (ArbitraryZipper (Zipper left middle right)) = coarbitrary left >>> coarbitrary middle >>> coarbitrary right
 
 -- Wrapping Zipper functions for ArbitraryZipper
@@ -130,18 +125,18 @@ beginning (ArbitraryZipper zipper) = ArbitraryZipper $ Zipper.beginning zipper
 end :: forall a. ArbitraryZipper a -> ArbitraryZipper a
 end (ArbitraryZipper zipper) = ArbitraryZipper $ Zipper.end zipper
 
-toUnfoldable :: forall a f. (Unfoldable f) => ArbitraryZipper a -> f a
+toUnfoldable :: forall a f. Unfoldable f => ArbitraryZipper a -> f a
 toUnfoldable (ArbitraryZipper zipper) = Zipper.toUnfoldable zipper
 
-fromFoldable :: forall a f. (Foldable f) => f a -> Maybe (ArbitraryZipper a)
+fromFoldable :: forall a f. Foldable f => f a -> Maybe (ArbitraryZipper a)
 fromFoldable f = ArbitraryZipper <$> Zipper.fromFoldable f
 
 -- Purescript will someday be able to derive most of the rest of these ...
 -- see https://github.com/purescript/purescript/issues/514.
-instance showArbitraryZipper :: (Show a) => Show (ArbitraryZipper a) where
+instance showArbitraryZipper :: Show a => Show (ArbitraryZipper a) where
     show (ArbitraryZipper zipper) = show zipper
 
-instance eqArbitraryZipper :: (Eq a) => Eq (ArbitraryZipper a) where
+instance eqArbitraryZipper :: Eq a => Eq (ArbitraryZipper a) where
     eq (ArbitraryZipper zipper1) (ArbitraryZipper zipper2) = eq zipper1 zipper2
 
 instance functorArbitraryZipper :: Functor ArbitraryZipper where


### PR DESCRIPTION
This PR bumps the dependencies to work with psc 0.10.1.

I'm also suggesting bumping this libs version to 1.0.0 as its API looks fairly good and haven't been changed in a while.